### PR TITLE
Expand on brand lift use cases

### DIFF
--- a/advertising101.md
+++ b/advertising101.md
@@ -91,8 +91,8 @@ A robust free press is essential for a free society, and the explosion of freely
  Much discourse about the health of the media focuses on consumers' willingness to pay for news; too little focuses on consumers'
  *ability* to pay. An annual subscription to The New York Times costs ~$191/year. A subscription to the Wall Street
  Journal costs $515/year. In other words, a subscription to *just one single publication* can cost 1.5% of the US median individual income. 
- The fact is that paying for all the information necessary to be a well-informed citizen is prohibitively
- for many people (even moreso for people living in marginalized communities or in less wealthy countries.) 
+ The fact is that paying for all the information necessary to be a well-informed citizen is prohibitively expensive
+ for many people (even moreso for people in marginalized communities or in less wealthy countries.) 
  
  In a real sense, consuming advertising is selling one's attention. For the many people who do not have disposable money to spend on news,
  there is real value in being able to sell their attention in exchange for information and services they'd be otherwise unable to access.

--- a/advertising101.md
+++ b/advertising101.md
@@ -62,7 +62,8 @@ Once delivered, engagement and impact with ads in a digital context can be under
 ### Why is digital marketing socially important?
 
 Imagine digital marketing disappeared, perhaps because of legislation or technological changes. Who would be hurt? Obviously
-the technology companies who profit off digital advertising would disappear, but there would be other casualties, in particular:
+the technology companies who profit off digital advertising would disappear but there would also be other less direct 
+casualties, in particular:
 
 ##### Publishers
 
@@ -71,29 +72,31 @@ from digital advertising. [Research shows](http://www.digitalnewsreport.org/surv
 only about 11% of people are willing to pay for news subscriptions, and that half of all U.S. news subscriptions go to 
 the Washington Post or New York Times, which means smaller news outlets are disproportionately dependent on ad revenue.
 
-The current COVID-19 pandemic has proven to be a grim natural experiment highlighting how tenuous the business models of
-modern news media are. News sites have seen reductions of [1/3 to 1/2 in advertising spending](https://www.nytimes.com/2020/04/14/business/los-angeles-times-furloughs-cuts.html), which has lead to [layoffs 
-and furloughs affecting ~36,000 news media employees](https://www.nytimes.com/2020/04/10/business/media/news-media-coronavirus-jobs.html) (and counting).
-These loses of revenue are *less than* the decline of 50-60% in revenue that [Google itself has estimated](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf) publishers stand to lose
-if current cookie-based advertising techniques are disabled.  
+Smaller news outlets have already been struggling over the last decade, and the business models they currently have are 
+highly tenuous. The current COVID-19 pandemic has proven to be a grim natural experiment highlighting just how tenuous 
+those business models are. The economic and media conditions surrounding COVID-19 have lead to [reductions of 1/3 to 1/2 in advertising spending](https://www.nytimes.com/2020/04/14/business/los-angeles-times-furloughs-cuts.html)
+in news media, which has lead to [layoffs and furloughs affecting ~36,000 news media employees](https://www.nytimes.com/2020/04/10/business/media/news-media-coronavirus-jobs.html) (and counting).
+The current loss of revenue is still *less than* the decline of 50-60% in revenue that [Google itself has estimated](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf) publishers stand to lose
+if current cookie-based advertising techniques are disabled and not adequately replaced.  
 
 A robust free press is essential for a free society, and the explosion of freely available information about every topic
- imaginable that's attended the growth of the web has been an incredible boon to human development and happiness. Newspapers
- have relied on advertising to fund journalism and increase circulation for as long as there have been newspapers at all. 
- Non-digital advertising is waning rapidly, and if all advertising moves to digital channels which independent or sub-scale
- publishers can't access, then those publishers (and the numerous social benefits they provide) will simply disappear.
+ imaginable on the web has been an incredible boon to human development and happiness. For as long as newspapers have existed 
+ (all the way back to the 1700's) newspapers
+ have relied on advertising to fund journalism and distribution. 
+ As more and more media moves online, non-digital advertising is waning rapidly. If all advertising moves to digital channels which independent or sub-scale
+ publishers can't access then those publishers (and the numerous social benefits they provide) will simply disappear.
  
  ##### Consumers
  
  Much discourse about the health of the media focuses on consumers' willingness to pay for news; too little focuses on consumers'
- *ability* to pay. An annual subscription to The New York Times costs nearly $191/year. A subscription to the Wall Street
- Journal costs $515/year. In other words, a subscription to the WSJ costs 1.5% of the US median individual income *for a single publication*.
+ *ability* to pay. An annual subscription to The New York Times costs ~$191/year. A subscription to the Wall Street
+ Journal costs $515/year. In other words, a subscription to *just one single publication* can cost 1.5% of the US median individual income. 
+ The fact is that paying for all the information necessary to be a well-informed citizen is prohibitively
+ for many people (even moreso for people living in marginalized communities or in less wealthy countries.) 
  
- The simple fact is that paying for all the information necessary to be a well-informed citizen is simply prohibitively
- for many people (even moreso for people living in marginalized communities or in less wealthy countries.) In a real sense,
- consuming advertising is selling one's attention. For the many people who do not have disposable money to spend on news,
+ In a real sense, consuming advertising is selling one's attention. For the many people who do not have disposable money to spend on news,
  there is real value in being able to sell their attention in exchange for information and services they'd be otherwise unable to access.
- And if consumers are going to sell their attention, it's in their interest to get the highest price for that attention they can.
+ If consumers are going to sell their attention, it's in their interest to get the highest price for that attention they can.
  
  If digital advertising disappears, or the value of advertising drops precipitously, the wealthy will still find a way to get
  the information they need. Everyone else won't.       

--- a/advertising101.md
+++ b/advertising101.md
@@ -6,6 +6,7 @@ Background paper for the W3C Advertising Business Group. Draft, updated 2020-04-
 Contributors:
 * Wil Schobeiri (wschobeiri@mediamath.com)
 * Laura Carrier (lcarrier@mediamath.com)
+* George London (george@survata.com)
 
 This document describes the purpose and common uses cases for digital advertising, and attempts to connect them with technological solutions currently in use by the web ecosystem. 
 
@@ -58,6 +59,44 @@ Getting this wrong can be costly, damaging, or potentially even illegal. Adverti
 
 Once delivered, engagement and impact with ads in a digital context can be understood and measured in a way not possible in traditional advertising. Digital advertising enables marketers to demonstrate return on investment (ROI) and tangible business results that most modern businesses demand for any expenditure to be renewed. “Was my marketing effective? How effective was it? How much more revenue will we drive if I spend this much more on it?” are all questions that can be answered today.
 
+### Why is digital marketing socially important?
+
+Imagine digital marketing disappeared, perhaps because of legislation or technological changes. Who would be hurt? Obviously
+the technology companies who profit off digital advertising would disappear, but there would be other casualties, in particular:
+
+##### Publishers
+
+About a third (35%) of [newspaper ad revenue now comes](https://www.pewresearch.org/fact-tank/2019/07/23/key-takeaways-state-of-the-news-media-2018/) 
+from digital advertising. [Research shows](http://www.digitalnewsreport.org/survey/2019/overview-key-findings-2019/) that 
+only about 11% of people are willing to pay for news subscriptions, and that half of all U.S. news subscriptions go to 
+the Washington Post or New York Times, which means smaller news outlets are disproportionately dependent on ad revenue.
+
+The current COVID-19 pandemic has proven to be a grim natural experiment highlighting how tenuous the business models of
+modern news media are. News sites have seen reductions of [1/3 to 1/2 in advertising spending](https://www.nytimes.com/2020/04/14/business/los-angeles-times-furloughs-cuts.html), which has lead to [layoffs 
+and furloughs affecting ~36,000 news media employees](https://www.nytimes.com/2020/04/10/business/media/news-media-coronavirus-jobs.html) (and counting).
+These loses of revenue are *less than* the decline of 50-60% in revenue that [Google itself has estimated](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf) publishers stand to lose
+if current cookie-based advertising techniques are disabled.  
+
+A robust free press is essential for a free society, and the explosion of freely available information about every topic
+ imaginable that's attended the growth of the web has been an incredible boon to human development and happiness. Newspapers
+ have relied on advertising to fund journalism and increase circulation for as long as there have been newspapers at all. 
+ Non-digital advertising is waning rapidly, and if all advertising moves to digital channels which independent or sub-scale
+ publishers can't access, then those publishers (and the numerous social benefits they provide) will simply disappear.
+ 
+ ##### Consumers
+ 
+ Much discourse about the health of the media focuses on consumers' willingness to pay for news; too little focuses on consumers'
+ *ability* to pay. An annual subscription to The New York Times costs nearly $191/year. A subscription to the Wall Street
+ Journal costs $515/year. In other words, a subscription to the WSJ costs 1.5% of the US median individual income *for a single publication*.
+ 
+ The simple fact is that paying for all the information necessary to be a well-informed citizen is simply prohibitively
+ for many people (even moreso for people living in marginalized communities or in less wealthy countries.) In a real sense,
+ consuming advertising is selling one's attention. For the many people who do not have disposable money to spend on news,
+ there is real value in being able to sell their attention in exchange for information and services they'd be otherwise unable to access.
+ And if consumers are going to sell their attention, it's in their interest to get the highest price for that attention they can.
+ 
+ If digital advertising disappears, or the value of advertising drops precipitously, the wealthy will still find a way to get
+ the information they need. Everyone else won't.       
 
 ## Definitions & Strategies
 

--- a/advertising101.md
+++ b/advertising101.md
@@ -190,7 +190,35 @@ Marketer (consumer packaged goods brand): I know little about this consumer othe
 
 *Customer*: What the retail marketer does not know about me is that I have gotten re-married and my new wife prefers another retailer. We have noticed that there have been some significant shipping issues of late that we are both not happy with. So, now we are open to finding a retailer who carries the brands of childcare products that we need (including, but expanded beyond diapers) and who can get us those products reliably and quickly. In the ads I’ve seen, this retailer messaged that they can now get me goods in <3 days. I mention this retailer to my wife after seeing a few of the ads, and she makes our next purchase from them
 
-**_Scenario Five: Digital Marketing to Incentivize Store Visits_**
+**_Scenario Five: Brand Messaging_**
+
+*Marketer*: My company believes strongly in protecting the health of the next generation and the 
+health of the planet they will inherit. We avoid using any potentially harmful chemicals in our diapers.
+Unfortunately, our competitors don't share our scruples and so our diapers are not the cheapest on the market.
+
+We believe that most parents share our values but have never thought about the sustainability of their diapers. 
+ So they will make their purchasing decision based purely on fit and price **unless**
+they're made aware of the environmental and health implications of their decision. My company decides to run a large 
+advertising campaign emphasizing the sustainable composition of our diapers. Our goal is not to drive immediate sales but
+rather to make new parents aware that not all diapers are sustainable, even if that might benefit some of our 
+competitors who also limit harmful chemicals.
+  
+* Customers who already purchase our diapers are likely already aware of our message, so we want to target our campaign 
+to new parents who are not already customers. We purchase "segments" containing lists of new parents and to keep costs down 
+we use our CRM to suppress targeting parents who are already customers.  
+* Our CFO is skeptical that our ad campaign is a good use of money, particularly when we tell him it won't drive 
+immediately observable sales. So we contract with a brand lift measurement vendor to run an attitudinal lift study on our campaign.
+The measurement partner integrates a tracking tag into our advertisements and then uses that tracking information to survey parents who saw our ads and ask 
+them "to what extent do you agree that diapers from {{My Brand}} are free of harmful chemicals?".
+* Based on the results of the measurement study, I refine my creatives and targeting until I see a clear lift in consumer awareness.
+My CFO is pleased by the statistically rigorous results and authorizes a new campaign to run in the fall.
+
+*Customer*: As new parents, we didn't realize that some diaper manufacturers cut corners and include chemicals in their diapers
+that are bad for the environment or even potentially unhealthy for my baby. I'm glad that I saw a video on Youtube that 
+explained to me which chemicals to watch out for and which companies prioritize safety. I now research my diaper purchases
+carefully before making them, and I'm happy to spend a few more dollars on the sustainable option.
+
+**_Scenario Six: Digital Marketing to Incentivize Store Visits_**
 
 *Marketer (retailer)*: I am opening a new store and I would like to let consumers in the neighborhood know about the opening and incentivize them to come visit the store.
 * I ask them to target based on zip code for all zip codes within 20 miles of my store with brand messaging

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -16,30 +16,30 @@ This document is broken down into 4 main sections based on the needs of the vari
 
 ## Basic Advertiser Needs
 
-All advertising aims to drive an outcome. Just as there are are many types of ads, 
-there are many types of desireable outcomes. These outcomes differ along several key axes:
+All advertising aims to drive an outcome. There are many types of desirable outcomes, and these outcomes differ along several key axes:
 
-1. **Immediate vs delayed**: is someone signing up to be an Uber driver right now,
-or are they just supposed to remember to consider a Mercedes next time they're buying a car?
-2. **Objective vs. subjective**: is someone taking a specific action like dialing a lawyer's office, or are they
-just remembering to "Think Different"?
-3. **Direct vs. Indirect**: is someone buying glasses directly from Warby Parker, or are they buying Ray-Ban's from their
- local optician after seeing a Youtube ad?
+1. **Immediate vs delayed**: signing up to be an Uber driver right now,
+vs. remembering to consider a Mercedes next time they're buying a car
+2. **Objective vs. subjective**: taking a specific action like dialing a lawyer's office vs.
+just remembering to "Think Different"
+3. **Direct vs. Indirect**: buying glasses directly from warbyparker.com, vs. buying Ray-Ban's from their
+ local optician after seeing a Youtube ad
  
 Outcomes that are immediate, objective, and direct are typically referred to as "conversions" and the type of
 advertising that prioritizes conversions is typically called "direct response advertising". Conversely, advertising that
 focuses on outcomes that delayed, subjective, and often indirect is typically called "brand advertising."
 
-Direct response advertising has a long and successful history on the internet, but brand advertising in recent years has
-become increasingly prevalent online, particularly on premium publishers like the Washington Post and New York Times.
-Precise statistics are hard to come by, but by [some estimates](https://www.marketingdive.com/news/42-of-ad-spend-on-amazon-goes-toward-brand-awareness-study-says/565740/) brand advertising makes up over ~1/3 of all digital advertising. 
+Both types of advertising are prevalent on the internet, and many ad campaigns by larger advertisers include a blend of
+ both types. Direct response advertising represents the lion's share of digital advertising, but in recent years 
+ spending on digital brand advertising has grown rapidly, particularly on premium publishers like the Washington Post and The New York Times.
+Precise statistics are hard to come by, but by [some estimates](https://www.marketingdive.com/news/42-of-ad-spend-on-amazon-goes-toward-brand-awareness-study-says/565740/) brand advertising makes up 1/3 or more of all digital advertising. 
 
 When an advertiser spends money to run an ad campaign they want to answer three very basic questions about it:
 - How many people saw the ad?
 - How successful was the campaign at driving the desired outcomes/conversions?
 - Are you confident that the ad impressions and ad conversions are from real, authentic people?
 
-Although they sound like simple questions, in practice answering them well is rather complex and difficult undertaking. 
+Although they sound like simple questions, in practice answering them well is a rather complex and difficult undertaking. 
 The ads industry has endeavored to find good ways of answering these basic questions, and has developed a number of approaches to doing so, which is why there are more than 3 use-cases in this section.
 
 - [Impression and Viewability Measurement](#impression-and-viewability-measurement)

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -184,12 +184,11 @@ The total number of raw conversion events is counted in both groups, and the dif
 ## Attitudinal Lift Measurement
 
 Much like direct response advertisers want to know how many incremental conversions were caused by their ad campaigns, 
-brand advertisers want to know whether their ad campaigns succeeded in causing their desired outcomes. Unlike in direct
-response, the targeted outcomes are usually not observable conversions but rather subjective changes in consumers awareness
-of, intent to purchase, or feelings of favorability towards a particular brand, service, or product.
+brand advertisers want to know whether their ad campaigns succeeded in making consumers more aware of, interested in, or
+favorable towards their brand, product, or service.
 
-Because these outcomes are not linked to a discrete observable action (like an online purchase), they must instead be 
-measured (typically) through surveys that ask questions like "how likely are you to purchase a Toyota next time you're
+Because these attitudinal outcomes are not linked to a discrete observable action (like an online purchase), they typically 
+must instead be measured through surveys that ask questions like "how likely are you to purchase a Toyota next time you're
 in the market for a car?"
 
 Lift is measured by comparing the prevalence of a given answer among an "exposed" group of respondents who have seen a 
@@ -197,37 +196,34 @@ particular ad campaign compared to the prevalence of that same answer among a co
 
 When possible, the exposed and control groups should be randomly selected prior to running the test to ensure they are well balanced.
 However random selection is not always feasible because it may require advertisers to purchase ad space in order to **not** show ads to 
-the control group, which many advertisers find prohibitively expensive. But even if random selection is not used, surveys can
-be designed to capture pre-existing differences between exposed and control groups and thus allow recovering an accurate estimate of
+the control group, which many advertisers find prohibitively expensive. But even when random selection is not used, surveys can
+be designed to capture pre-existing differences between exposed and control groups through tailored questions and thus allow recovering an accurate estimate of
 lift using a statistical process known as "casual inference".
 
-Measuring attitudinal lift involves substantial challenges that aren't involved in measuring conversion lift:
+Measuring attitudinal lift adds substantial challenges beyond those already involved in measuring conversion lift:
  
- 1. Brand advertising by nature rarely produces clicks. For example, video advertising - the fastest growing online ad 
- format - is almost all intended to drive brand outcomes (like awareness), not clicks. This means that any browser API that requires
+ 1. Brand advertising rarely produces clicks (or any other direct interaction with the ad unit). For example, video advertising - the [fastest growing online ad 
+ format](https://www.iab.com/wp-content/uploads/2019/10/IAB-HY19-Internet-Advertising-Revenue-Report.pdf) - is almost all intended to drive brand outcomes (like awareness), not clicks. This means that any browser API that requires
  clicks to operate will not be suitable for Attitudinal Lift Measurement (though API's that support "view-through conversions" 
  may potentially be sufficient.)    
- 2. Increasing favorability towards Toyota is fundamentally different than increasing favorability towards Honda and so a Toyota 
+ 2. Favorability towards Toyota is fundamentally different than favorability towards BMW and so a Toyota 
 ad campaign can only be measured by a survey that specifically asks about attitudes towards Toyota in particular. Because surveys 
 are expensive to administer, it would be uneconomical to survey hundreds of thousands of consumers about their attitudes
- towards every car brand, hoping that enough of them turn out to have seen a Toyota ad in order to estimate lift for that campaign. Instead, surveys must be 
-kept brief and must be narrowly targeted to people who have seen *particular* ad campaigns (or are in a control group with respect
+ towards every car brand, hoping that enough of them turn out to have seen a Toyota ad. Instead, surveys must be 
+kept brief and must be narrowly targeted to people who have seen *specific* ad campaigns (or are in a control group with respect
 to that particular ad campaign).
 
-The necessity of targeting particular surveys to particular respondents means that at some point, some system must select
-the right survey to show to a particular person. And that system must make the decision based on that person's past exposure
-(or non-exposure) to a particular ad. This may not be a problem in 1st party contexts where a particular publisher running
+The necessity of targeting specific surveys to particular respondents means that at some point, some system must select
+the right survey to show to a particular person. And that decision can only be based on that person's past exposure
+(or non-exposure) to particular ads. This selection may not be a privacy problem in 1st party contexts where a particular publisher running
 an on-site survey just needs to record which ads a particular user has seen on that 1st party domain. (Though that itself 
 might be a problem if publishers are blinded to the ads served via a system like TURTLEDOVE.)
 
-While some surveys are conducted in a 1st party context (e.g. Youtube conducts its own internal brand measurement studies),
+While some large publishers (e.g. Youtube) do conducted their own brand measurement surveys in a 1st party context,
 advertisers are understandably reluctant to allow publishers to "grade their own homework." Also, the vast majority of 
-brand campaigns are conducted on many different channels simultaneously and even if it weren't prohibitively burdensome 
-for advertisers to aggregate individual survey results from each channel, it would be prohibitively difficult for small, 
-independent publishers to administer their own survey systems. Thus the large majority of                                                              
-attitudinal lift measurement is conducted via 3rd party channels (either by intercepting visitors on other websites, or by
-using 3rd party panels) who can report on campaigns across domains and can develop their own expertise in the practice of survey administration and
-statistical analysis. 
+brand campaigns are conducted on many different channels simultaneously. Conducting and analyzing surveys requires expertise
+ that is unrealistic for small, independent publishers to develop and deploy on their own. Thus the large majority of                                                               attitudinal lift measurement is conducted via 3rd party channels (either by intercepting visitors on other websites, or by
+using 3rd party panels).
 
 When surveys are conducted on a different domain than the original ad exposure, the surveying domain must have some way
 to select the right survey to give based on the respondent's ad exposure profile across other domains.    

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -226,11 +226,16 @@ brand campaigns are conducted on many different channels simultaneously. Conduct
 using 3rd party panels).
 
 When surveys are conducted on a different domain than the original ad exposure, the surveying domain must have some way
-to select the right survey to give based on the respondent's ad exposure profile across other domains.    
+to select the right survey to give based on the respondent's ad exposure profile across other domains.
+
+Fortunately, the conclusions of attitudinal measurement are inherently statistical and aggregated, e.g. "this campaign increased awareness by 
+10% among those who saw it". The responses any individual are irrelevant beyond their contribution to a summary statistic.
+ If a privacy-safe way to collect and aggregate the the survey data can be devised, measurement providers have no 
+ further need to retain any information about individuals.    
 
 ## Click-through and View-through attribution heuristics
 
-The alternative approach is to use some heuristic to “attribute” conversions to ads. The two most popular heuristics are “click-through attribution” and “view-through attribution”. “Click-through attribution” gives credit to an ad if the person had previously clicked on the ad prior to the conversion event. “View-through attribution” gives credit to an ad if the person had previously seen the ad prior to the conversion event.
+The alternative to lift measurement is to use some heuristic to “attribute” conversions to ads. The two most popular heuristics are “click-through attribution” and “view-through attribution”. “Click-through attribution” gives credit to an ad if the person had previously clicked on the ad prior to the conversion event. “View-through attribution” gives credit to an ad if the person had previously seen the ad prior to the conversion event.
 
 Both attribution heuristics come with some concept of an “attribution window”. For example, a “one-day view-through” attribution window would only count conversions which happened within one day of an ad view. A “28-day click-through” attribution window would only count conversions which happened within 28 days of a click.
 

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -47,7 +47,8 @@ The ads industry has endeavored to find good ways of answering these basic quest
   - [Invalid Traffic](#invalid-traffic)
   - [Third Party Verification](#third-party-verification)
 - [Aggregate Conversion Measurement](#aggregate-conversion-measurement)
-  - [Lift Measurement](#lift-measurement)
+  - [Conversion Lift Measurement](#conversion-lift-measurement)
+  - [Attitudinal Lift Measurement](#attitudinal-lift-measurement)
   - [Click-through and View-through attribution heuristics](#click-through-and-view-through-attribution-heuristics)
   - [Multi-touch attribution](#multi-touch-attribution)
   - [Cross Browser / Cross Device Measurement](#cross-browser--cross-device-measurement)
@@ -61,7 +62,8 @@ The ads industry has endeavored to find good ways of answering these basic quest
 | Use-case | Chrome | Safari | Community Proposals |
 |----------|--------|--------|---------------------|
 | [Impression and Viewability Measurement](#impression-and-viewability-measurement) | There should be no conflict with Chrome’s proposed “[Privacy Model for the Web](https://github.com/michaelkleber/privacy-model)”. First parties should still be capable of measuring that the ads displayed on their own properties entered the viewport, that images and video were loaded, how much time they spent in the viewport, etc. None of this requires joining up user identity across multiple domains. The only possible complication that might arise would be with "blind rendering" as described in proposals like "[TURTLEDOVE](https://github.com/michaelkleber/turtledove)" and “[PETREL](https://github.com/w3c/web-advertising/blob/master/PETREL.md)”. Here, the publisher would have restricted access to the ad being rendered and we will have to discuss the feasibility of "viewability" measurement. There is a discussion on this [GitHub issue](https://github.com/csharrison/aggregate-reporting-api/issues/10). | Similar answer as that for Chrome. This should not be in conflict with Webkit's [Tracking Prevention Policy](https://webkit.org/tracking-prevention-policy/) given the measurement is entirely within the scope of a single publisher website. | | 
-| [Lift Measurement](#lift-measurement) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions, which should be sufficient to support lift measurement using experiments on a first party site (e.g. when using a first-party identifier to decide which experiment branch a person is in). | No support | Facebook proposal for “[Private Lift Measurement](https://github.com/w3c/web-advertising/blob/master/private-lift-measurement-conceptual-overview.md)” |
+| [Conversion Lift Measurement](#conversion-lift-measurement) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions, which should be sufficient to support lift measurement using experiments on a first party site (e.g. when using a first-party identifier to decide which experiment branch a person is in). | No support | Facebook proposal for “[Private Lift Measurement](https://github.com/w3c/web-advertising/blob/master/private-lift-measurement-conceptual-overview.md)” |
+| [Attitudinal Lift Measurement](#attitudinal-lift-measurement) | No support | No support | No support | |
 | [Click-through attribution](#click-through-and-view-through-attribution-heuristics) | Proposal: “[Click Through Conversion-Measurement Event-level API](https://github.com/WICG/conversion-measurement-api)” | Proposal: “[Private Click Measurement API](https://github.com/WICG/ad-click-attribution)” |
 | [View-through attribution](#click-through-and-view-through-attribution-heuristics) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions. | No support | |
 | [Multi-touch attribution](#multi-touch-attribution) | The [Event-level API](https://github.com/WICG/conversion-measurement-api/blob/master/README.md) proposal covers last-click attribution.  A section of the [Conversion Measurement with Aggregation](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#multi-touch-attribution-mta) proposal describes support for some built-in multi-touch models, and acknowledges that measurement providers writing their own models would be good to support if technically feasible. | No support | Facebook proposal for “[Privacy-Preserving Multi-Touch-Attribution and Cross-Publisher Lift Measurement](https://github.com/w3c/web-advertising/blob/master/privacy_preserving_multi_touch_attribution_and_cross_publisher_lift_measurement.md)” |
@@ -173,11 +175,15 @@ These use-cases are more focused on the publisher's perspective.
 
 Advertisers need to know how many conversions happened as a result of their ad campaigns. 
 
-## Lift Measurement
+## Conversion Lift Measurement
 
 Ideally advertisers would like to know how many conversions were caused by their ad campaign (i.e. would not have happened were it not for this ad campaign). This is variously refered to as "causality" or "incrementality" measurement. The gold standard measurement approach to answer this question is “Lift Measurement”. This involves a “test group” who is shown ads, and a “control group” who is not shown ads. These groups should be randomly selected prior to running the test to ensure they are well balanced. 
 
 The total number of raw conversion events is counted in both groups, and the difference between the two is called the “lift”. If this is a statistically significant value, and the test and control groups were selected randomly, the only explanation for the difference is the causal effect of the ads.
+
+## Attitudinal Lift Measurement
+
+TBD
 
 ## Click-through and View-through attribution heuristics
 

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -198,7 +198,7 @@ When possible, the exposed and control groups should be randomly selected prior 
 However random selection is not always feasible because it may require advertisers to purchase ad space in order to **not** show ads to 
 the control group, which many advertisers find prohibitively expensive. But even when random selection is not used, surveys can
 be designed to capture pre-existing differences between exposed and control groups through tailored questions and thus allow recovering an accurate estimate of
-lift using a statistical process known as "casual inference".
+lift using a statistical process known as ["casual inference"](https://en.wikipedia.org/wiki/Causal_inference).
 
 Measuring attitudinal lift adds substantial challenges beyond those already involved in measuring conversion lift:
  
@@ -206,7 +206,7 @@ Measuring attitudinal lift adds substantial challenges beyond those already invo
  format](https://www.iab.com/wp-content/uploads/2019/10/IAB-HY19-Internet-Advertising-Revenue-Report.pdf) - is almost all intended to drive brand outcomes (like awareness), not clicks. This means that any browser API that requires
  clicks to operate will not be suitable for Attitudinal Lift Measurement (though API's that support "view-through conversions" 
  may potentially be sufficient.)    
- 2. Favorability towards Toyota is fundamentally different than favorability towards BMW and so a Toyota 
+ 2. Favorability towards Toyota is fundamentally different than favorability towards BMW, and so a Toyota 
 ad campaign can only be measured by a survey that specifically asks about attitudes towards Toyota in particular. Because surveys 
 are expensive to administer, it would be uneconomical to survey hundreds of thousands of consumers about their attitudes
  towards every car brand, hoping that enough of them turn out to have seen a Toyota ad. Instead, surveys must be 
@@ -219,7 +219,7 @@ the right survey to show to a particular person. And that decision can only be b
 an on-site survey just needs to record which ads a particular user has seen on that 1st party domain. (Though that itself 
 might be a problem if publishers are blinded to the ads served via a system like TURTLEDOVE.)
 
-While some large publishers (e.g. Youtube) do conducted their own brand measurement surveys in a 1st party context,
+While some large publishers (e.g. Youtube) do conduct their own brand measurement surveys in a 1st party context,
 advertisers are understandably reluctant to allow publishers to "grade their own homework." Also, the vast majority of 
 brand campaigns are conducted on many different channels simultaneously. Conducting and analyzing surveys requires expertise
  that is unrealistic for small, independent publishers to develop and deploy on their own. Thus the large majority of                                                               attitudinal lift measurement is conducted via 3rd party channels (either by intercepting visitors on other websites, or by
@@ -229,7 +229,7 @@ When surveys are conducted on a different domain than the original ad exposure, 
 to select the right survey to give based on the respondent's ad exposure profile across other domains.
 
 Fortunately, the conclusions of attitudinal measurement are inherently statistical and aggregated, e.g. "this campaign increased awareness by 
-10% among those who saw it". The responses any individual are irrelevant beyond their contribution to a summary statistic.
+10% among those who saw it". The responses of any individual are irrelevant beyond their contribution to a summary statistic.
  If a privacy-safe way to collect and aggregate the the survey data can be devised, measurement providers have no 
  further need to retain any information about individuals.    
 

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -183,7 +183,54 @@ The total number of raw conversion events is counted in both groups, and the dif
 
 ## Attitudinal Lift Measurement
 
-TBD
+Much like direct response advertisers want to know how many incremental conversions were caused by their ad campaigns, 
+brand advertisers want to know whether their ad campaigns succeeded in causing their desired outcomes. Unlike in direct
+response, the targeted outcomes are usually not observable conversions but rather subjective changes in consumers awareness
+of, intent to purchase, or feelings of favorability towards a particular brand, service, or product.
+
+Because these outcomes are not linked to a discrete observable action (like an online purchase), they must instead be 
+measured (typically) through surveys that ask questions like "how likely are you to purchase a Toyota next time you're
+in the market for a car?"
+
+Lift is measured by comparing the prevalence of a given answer among an "exposed" group of respondents who have seen a 
+particular ad campaign compared to the prevalence of that same answer among a control group who have not seen the campaign.
+
+When possible, the exposed and control groups should be randomly selected prior to running the test to ensure they are well balanced.
+However random selection is not always feasible because it may require advertisers to purchase ad space in order to **not** show ads to 
+the control group, which many advertisers find prohibitively expensive. But even if random selection is not used, surveys can
+be designed to capture pre-existing differences between exposed and control groups and thus allow recovering an accurate estimate of
+lift using a statistical process known as "casual inference".
+
+Measuring attitudinal lift involves substantial challenges that aren't involved in measuring conversion lift:
+ 
+ 1. Brand advertising by nature rarely produces clicks. For example, video advertising - the fastest growing online ad 
+ format - is almost all intended to drive brand outcomes (like awareness), not clicks. This means that any browser API that requires
+ clicks to operate will not be suitable for Attitudinal Lift Measurement (though API's that support "view-through conversions" 
+ may potentially be sufficient.)    
+ 2. Increasing favorability towards Toyota is fundamentally different than increasing favorability towards Honda and so a Toyota 
+ad campaign can only be measured by a survey that specifically asks about attitudes towards Toyota in particular. Because surveys 
+are expensive to administer, it would be uneconomical to survey hundreds of thousands of consumers about their attitudes
+ towards every car brand, hoping that enough of them turn out to have seen a Toyota ad in order to estimate lift for that campaign. Instead, surveys must be 
+kept brief and must be narrowly targeted to people who have seen *particular* ad campaigns (or are in a control group with respect
+to that particular ad campaign).
+
+The necessity of targeting particular surveys to particular respondents means that at some point, some system must select
+the right survey to show to a particular person. And that system must make the decision based on that person's past exposure
+(or non-exposure) to a particular ad. This may not be a problem in 1st party contexts where a particular publisher running
+an on-site survey just needs to record which ads a particular user has seen on that 1st party domain. (Though that itself 
+might be a problem if publishers are blinded to the ads served via a system like TURTLEDOVE.)
+
+While some surveys are conducted in a 1st party context (e.g. Youtube conducts its own internal brand measurement studies),
+advertisers are understandably reluctant to allow publishers to "grade their own homework." Also, the vast majority of 
+brand campaigns are conducted on many different channels simultaneously and even if it weren't prohibitively burdensome 
+for advertisers to aggregate individual survey results from each channel, it would be prohibitively difficult for small, 
+independent publishers to administer their own survey systems. Thus the large majority of                                                              
+attitudinal lift measurement is conducted via 3rd party channels (either by intercepting visitors on other websites, or by
+using 3rd party panels) who can report on campaigns across domains and can develop their own expertise in the practice of survey administration and
+statistical analysis. 
+
+When surveys are conducted on a different domain than the original ad exposure, the surveying domain must have some way
+to select the right survey to give based on the respondent's ad exposure profile across other domains.    
 
 ## Click-through and View-through attribution heuristics
 

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -16,12 +16,31 @@ This document is broken down into 4 main sections based on the needs of the vari
 
 ## Basic Advertiser Needs
 
+All advertising aims to drive an outcome. Just as there are are many types of ads, 
+there are many types of desireable outcomes. These outcomes differ along several key axes:
+
+1. **Immediate vs delayed**: is someone signing up to be an Uber driver right now,
+or are they just supposed to remember to consider a Mercedes next time they're buying a car?
+2. **Objective vs. subjective**: is someone taking a specific action like dialing a lawyer's office, or are they
+just remembering to "Think Different"?
+3. **Direct vs. Indirect**: is someone buying glasses directly from Warby Parker, or are they buying Ray-Ban's from their
+ local optician after seeing a Youtube ad?
+ 
+Outcomes that are immediate, objective, and direct are typically referred to as "conversions" and the type of
+advertising that prioritizes conversions is typically called "direct response advertising". Conversely, advertising that
+focuses on outcomes that delayed, subjective, and often indirect is typically called "brand advertising."
+
+Direct response advertising has a long and successful history on the internet, but brand advertising in recent years has
+become increasingly prevalent online, particularly on premium publishers like the Washington Post and New York Times.
+Precise statistics are hard to come by, but by [some estimates](https://www.marketingdive.com/news/42-of-ad-spend-on-amazon-goes-toward-brand-awareness-study-says/565740/) brand advertising makes up over ~1/3 of all digital advertising. 
+
 When an advertiser spends money to run an ad campaign they want to answer three very basic questions about it:
 - How many people saw the ad?
-- How many conversions happened as a result of running this ad campaign?
+- How successful was the campaign at driving the desired outcomes/conversions?
 - Are you confident that the ad impressions and ad conversions are from real, authentic people?
 
-Although they sound like simple questions, in practice answering them well is rather complex and difficult undertaking. The ads industry has endeavored to find good ways of answering these basic questions, and has developed a number of approaches to doing so, which is why there are more than 3 use-cases in this section.
+Although they sound like simple questions, in practice answering them well is rather complex and difficult undertaking. 
+The ads industry has endeavored to find good ways of answering these basic questions, and has developed a number of approaches to doing so, which is why there are more than 3 use-cases in this section.
 
 - [Impression and Viewability Measurement](#impression-and-viewability-measurement)
   - [Viewability](#viewability)


### PR DESCRIPTION
Expanding the discussion of advertiser general needs to discuss the role of brand advertising in the digital advertising ecosystem.

Update the use cases document to discuss "Attitudinal Lift Measurement", the method by which the effectiveness of brand advertising is measured.