### PR TITLE
Add use case (and explanatory documentation) for "brand lift measurement"

### DIFF
--- a/advertising-outcomes.md
+++ b/advertising-outcomes.md
@@ -1,0 +1,46 @@
+# Potential Outcomes from Advertising
+
+All advertising aims to drive an outcome, but there are many different possible outcomes advertisers may be 
+willing to pay to achieve.
+ 
+ Some types of outcomes are much more direct and immediate than others. Immediate, direct 
+ outcomes (e.g. downloading a mobile poker app) are not inherently more valuable than delayed, indirect outcomes 
+ (e.g. buying an engagement ring made without "conflict" diamonds). But like any professional,
+ marketers face constant pressure to demonstrate the effectiveness of money spent on marketing and so will naturally
+ tend to prefer channels where it's easier to demonstrate the return on advertising spend over channels where the return is difficult to demonstrate.
+ 
+ This document aims to provide a list of the numerous target outcomes of advertising. This list can hopefully serve 
+ as a set of "test cases" to ensure that the privacy-preserving API's of the future web do not unintentionally
+ curtail particular channels of advertising by making their desired effects unduly difficult to measure.
+ 
+## Online Actions
+ 
+* Visiting a web page
+* Making an online purchase
+* Downloading an app
+* Subscribing to a service
+* Joining a mailing list
+* Viewing a video
+* Signing up for a webinar
+* Requesting a demo
+* "Sharing" a piece of content
+* Making a delayed online purchase (after more research, or on a more convenient device)
+
+## Offline
+
+### Attitudes
+* Becoming aware of a product or service
+* Becoming more favorable towards a brand
+* Becoming more likely to consider a brand, next time a consumer is the market for the product or service they offer
+* Developing intent to purchase a product at the next opportunity
+* Learning something about a brand (e.g. their use of sustainable ingredients)
+* Associating a message with a brand
+* Becoming more likely to recommend a brand they like to a friend
+
+### Actions
+* Dialing a phone number
+* Making an offline purchase
+* Visiting a store
+* Taking a test drive
+* Seeing a movie 
+* Touring a property

--- a/advertising101.md
+++ b/advertising101.md
@@ -6,6 +6,7 @@ Background paper for the W3C Advertising Business Group. Draft, updated 2020-04-
 Contributors:
 * Wil Schobeiri (wschobeiri@mediamath.com)
 * Laura Carrier (lcarrier@mediamath.com)
+* George London (george@survata.com)
 
 This document describes the purpose and common uses cases for digital advertising, and attempts to connect them with technological solutions currently in use by the web ecosystem. 
 
@@ -58,6 +59,51 @@ Getting this wrong can be costly, damaging, or potentially even illegal. Adverti
 
 Once delivered, engagement and impact with ads in a digital context can be understood and measured in a way not possible in traditional advertising. Digital advertising enables marketers to demonstrate return on investment (ROI) and tangible business results that most modern businesses demand for any expenditure to be renewed. “Was my marketing effective? How effective was it? How much more revenue will we drive if I spend this much more on it?” are all questions that can be answered today.
 
+### Why is digital advertising socially important?
+
+Imagine digital advertising withered or disappeared, perhaps because of legislation or technological changes. Who would be hurt? Obviously
+the technology companies who profit off digital advertising would disappear. But if digital advertising were to contract to
+ the point where it'd be no longer viable to operate businesses funded by digital advertising, there would also be other 
+ less direct casualties, in particular:
+
+##### Publishers
+
+About a third (35%) of [newspaper ad revenue now comes](https://www.pewresearch.org/fact-tank/2019/07/23/key-takeaways-state-of-the-news-media-2018/) 
+from digital advertising. [Research shows](http://www.digitalnewsreport.org/survey/2019/overview-key-findings-2019/) that 
+only about 11% of people are willing to pay for news subscriptions, and that half of all U.S. news subscriptions go to 
+the Washington Post or New York Times, which means all other national news outlets (as well as regional and local news outlets)
+ are disproportionately dependent on ad revenue.
+
+Smaller news outlets have already been struggling over the last decade, and the business models they currently have are 
+highly tenuous. The current COVID-19 pandemic has proven to be a grim natural experiment highlighting just how tenuous 
+those business models are. The economic and media conditions surrounding COVID-19 have lead to [reductions of 1/3 to 1/2 in advertising spending](https://www.nytimes.com/2020/04/14/business/los-angeles-times-furloughs-cuts.html)
+in news media, which has lead to [layoffs and furloughs affecting ~36,000 news media employees](https://www.nytimes.com/2020/04/10/business/media/news-media-coronavirus-jobs.html) (and counting).
+The current loss of revenue is still *less than* the decline of 50-60% in revenue that [Google itself has estimated](https://services.google.com/fh/files/misc/disabling_third-party_cookies_publisher_revenue.pdf) publishers stand to lose
+if current cookie-based advertising techniques are disabled and not adequately replaced.  
+
+A robust free press is essential for a free and open society, and the explosion of freely available information about every topic
+ imaginable on the web has been an incredible boon to human development and happiness. For as long as newspapers have existed 
+ (all the way back to the 1700's) newspapers
+ have relied on advertising to fund journalism and distribution. 
+ As more and more media moves online, non-digital advertising is waning rapidly. If all advertising moves to digital channels which independent or sub-scale
+ publishers can't access then those publishers (and the numerous social benefits they provide) will simply disappear.
+ 
+##### Consumers
+ 
+ Much discourse about the health of the media focuses on consumers' willingness to pay for news; too little focuses on consumers'
+ *ability* to pay. An annual subscription to The New York Times costs ~$191/year. A subscription to the Wall Street
+ Journal costs $515/year. In other words, a subscription to *just one single publication* can cost 1.5% of the US median individual income. 
+ The fact is that paying for all the information necessary to be a well-informed citizen is prohibitively expensive
+ for many people (even moreso for people in marginalized communities or in less wealthy countries). This is why so many 
+ news organizations have dropped their paywalls during the current pandemic, which of course only increases those news
+ organizations' dependency on advertising. 
+ 
+ In a real sense, consuming advertising is selling one's attention. For the many people who do not have disposable money to spend on news,
+ there is real value in being able to sell their attention in exchange for information and services they'd be otherwise unable to access.
+ If consumers are going to sell their attention, it's in their interest to get the highest price for that attention they can.
+ 
+ If digital advertising disappears, or the value of advertising drops precipitously, the wealthy will still find a way to get
+ the information they need. Everyone else won't.       
 
 ## Definitions & Strategies
 
@@ -148,7 +194,35 @@ Marketer (consumer packaged goods brand): I know little about this consumer othe
 
 *Customer*: What the retail marketer does not know about me is that I have gotten re-married and my new wife prefers another retailer. We have noticed that there have been some significant shipping issues of late that we are both not happy with. So, now we are open to finding a retailer who carries the brands of childcare products that we need (including, but expanded beyond diapers) and who can get us those products reliably and quickly. In the ads I’ve seen, this retailer messaged that they can now get me goods in <3 days. I mention this retailer to my wife after seeing a few of the ads, and she makes our next purchase from them
 
-**_Scenario Five: Digital Marketing to Incentivize Store Visits_**
+**_Scenario Five: Brand Messaging_**
+
+*Marketer*: My company believes strongly in protecting the health of the next generation and the 
+health of the planet they will inherit. We avoid using any potentially harmful chemicals in our diapers.
+Unfortunately, our competitors don't share our scruples and so our diapers are not the cheapest on the market.
+
+We believe that most parents share our values but have never thought about the sustainability of their diapers. 
+ So they will make their purchasing decision based purely on fit and price **unless**
+they're made aware of the environmental and health implications of their decision. My company decides to run a large 
+advertising campaign emphasizing the sustainable composition of our diapers. Our goal is not to drive immediate sales but
+rather to make new parents aware that not all diapers are sustainable, even if that might benefit some of our 
+competitors who also limit harmful chemicals.
+  
+* Customers who already purchase our diapers are likely already aware of our message, so we want to target our campaign 
+to new parents who are not already customers. We purchase "segments" containing lists of new parents and to keep costs down 
+we use our CRM to suppress targeting parents who are already customers.  
+* Our CFO is skeptical that our ad campaign is a good use of money, particularly when we tell him it won't drive 
+immediately observable sales. So we contract with a brand lift measurement vendor to run an brand lift study on our campaign.
+The measurement partner integrates a tracking tag into our advertisements and then uses that tracking information to survey parents who saw our ads and ask 
+them "to what extent do you agree that diapers from {{My Brand}} are free of harmful chemicals?".
+* Based on the results of the measurement study, I refine my creatives and targeting until I see a clear lift in consumer awareness.
+My CFO is pleased by the statistically rigorous results and authorizes a new campaign to run in the fall.
+
+*Customer*: As new parents, we didn't realize that some diaper manufacturers cut corners and include chemicals in their diapers
+that are bad for the environment or even potentially unhealthy for our baby. I'm glad that I saw a video ad on Youtube that 
+explained to me which chemicals to watch out for and which companies prioritize safety. I now research my diaper purchases
+carefully before making them, and I'm happy to spend a few more dollars on the sustainable option.
+
+**_Scenario Six: Digital Marketing to Incentivize Store Visits_**
 
 *Marketer (retailer)*: I am opening a new store and I would like to let consumers in the neighborhood know about the opening and incentivize them to come visit the store.
 * I ask them to target based on zip code for all zip codes within 20 miles of my store with brand messaging

--- a/brand_lift_overview.md
+++ b/brand_lift_overview.md
@@ -1,0 +1,338 @@
+# How of Brand Lift Measurement Works (And What'll Be Required to Support It)
+
+## Introduction
+
+Advertisers work extensively with measurement vendors to measure
+the "lift" caused by brand advertising campaigns. The deprecation of 3rd party cookies in Chrome will break several key
+ pieces of the current flow and thus disable essentially all current measurement of brand lift by neutral third 
+ parties on the web.
+
+Any discussion of new browser APIs or API features to support cookieless brand lift measurement will (hopefully) be 
+more fruitful when grounded in a concrete, shared understanding of how brand lift measurement currently works. 
+ 
+To initiate and facilitate such a discussion, this document covers:
+ 
+ 1. What brand lift measurement is and why it's important to the economic health of the open web;
+ 2. Why brand lift measurement needs to be conducted by neutral third party vendors;
+ 3. How brand lift measurement currently works, with an emphasis on which parts of the process will be broken by
+ the upcoming deprecation of third party cookies;
+ 4. Why there are no viable alternatives to the current system (and therefore why new APIs will likely be needed
+ to preserve the brand lift measurement use case).
+ 
+ This document is intended to be read after the discussion of
+ brand advertising and brand lift measurement in [Advertising 101](advertising101.md) and 
+ after the discussion of the brand lift measurement use case in the "[Support for
+ Advertising Use Cases](support_for_advertising_use_cases.md)" document. Those documents
+ more extensively explain brand advertising, brand lift measurement, and why they're 
+ important to the web ecosystem. 
+
+## Background
+
+As discussed in the [Advertising 101](advertising101.md) document in this respository, all advertising aims to 
+achieve some outcome. Common outcomes are clicks, 
+online purchases, offline purchases, and increased favorability towards brands. Advertising that aims to drive immediate 
+outcomes (i.e. "conversions") is referred to as "direct response" advertising, whereas advertising that aims to drive
+outcomes that are delayed, indirect, or subjective is referred to as "brand advertising". (Please see "[Advertising Outcomes](advertising_outcomes.md)"
+for a more complete overview of the types of outcomes advertising aims to drive).
+
+The proposals in Google's ["Privacy Sandbox"](https://www.chromium.org/Home/chromium-privacy/privacy-sandbox) provide
+advertisers with several strong options for measuring the effectiveness of direct response advertising in driving conversions. 
+Facebook's proposal for "Private Lift Measurement" provides additional options for rigorous statistical measurement of
+the impact of advertising on conversions.
+
+However, no proposals currently under discussion will allow the measurement of brand advertising by neutral third parties 
+(as is the current standard practice). Measuring lift from brand advertising involves several additional challenges beyond what's
+required to measure lift in conversions.
+
+### Why Brand Lift Measurement Matters
+
+In essentially all cases, advertisers view advertising as an investment and calibrate how much money to spend
+on advertising based on the size/strength of the outcomes they expect that spending to drive. Most businesses
+face constant pressure to increase how efficiently they deploy capital and so marketing budgets are under constant 
+pressure to justify themselves. Advertising channels where efficacy and ROI are difficult to measure face substantial
+ headwinds in drawing advertising spending, even though there is no *a priori* reason to assume that easy-to-measure
+ channels are actually any more effective.
+ 
+Any channels that are made more difficult (or impossible) to measure by the the deprecation of 3rd party
+ cookies will see an outflow of marketing dollars (towards channels which remain easier to measure). As a result,
+ publishers who rely on newly-difficult-to-measure channels will suffer economic harm, while publishers who control
+ easier-to-measure channels will benefit. Brand advertising is particularly common on premium, independent publishers
+ both large (such as the New York Times) and small (such as community newspapers). If measuring brand advertising 
+ ceases to be viable, independent journalism will be deeply hurt.
+   
+### Why Measurement Requires Third Parties
+
+Most large brand advertising campaigns are conducted across many channels at once. It's not uncommon for a single campaign
+to involve banner ads run on dozens of publishers, video ads run on dozens of different publishers, television ads,
+ads run inside of native apps, and ads run on social platforms.
+
+The brand's goal is to know how well the campaign worked overall and whether it was a judicious use of money. Knowing how
+well individual channels performed is important, but it's primarily important in the context of how different channels
+performed compared to each other and compared to the overall campaign. So the brand needs a measurement vendor who can measure
+as much of the campaign as possible, across as many different channels as possible, and report consolidated results that
+make an apples-to-apples comparision between different channels. If results between channels are incommensurable, e.g.
+because there are (even slight) differences in the time period covered or the definition of the KPI's then the
+results become much less useful. 
+
+Moreover, each of these channels charges for advertising space. If the brand simply asks "Website XYZ, could you please
+ tell me how effective ads I run on your website are, so I can decide whether to give you less money?" then it is understandable that the self-reported efficacy numbers the
+brand receives will be viewed as less than fully reliable.
+
+Third party measurement companies are the only ones in a position to provide neutral, reliable reporting. They can 
+measure as many channels as the campaign runs on, and can align measurement so results across channels are presented in
+the same units and can be directly compared (i.e. "apples-to-apples"). Moreover they have the proper incentives
+to provide fair and neutral analysis - they serve as agents of the advertiser and have no incentive to favor one 
+channel/publisher over another. Please the section on [1st party measurement](#1st party measurement) below for a deeper
+discussion of why measurement requires third parties.
+
+## A Worked Example
+
+### The Parties
+
+Suppose ShoeCo is launching a new line of custom-fitted basketball shoes, JumpJetz, designed to promote higher jumping. 
+
+The product is brand new, and the special fittings it requires mean it can only be sold in physical stores (not online).
+ JumpJetz received rave reviews in focus groups, but ShoeCo knows that no one will think to buy it at the mall unless they learn it exists and learn
+about its unique benefits. So ShoeCo works with AdAgencyCo to design and conduct a massive national brand advertising
+campaign introducing North America to JumpJetz.
+
+Initial market research suggests that basketball shoes are of particular interest to people under the age of 45. So the 
+ad agency recommends targeting the campaign towards news outlets focused on sports and on outlets catering to Millenials
+ and GenZ. They also suggest targeting towards people who have recently read content about basketball or basketball shoes.
+ 
+ The brand and the agency agree that because JumpJetz are brand new, the KPI for this campaign will be simply "awareness",
+ i.e. the percentage of Americans who are at least aware that JumpJetz exists and are a brand of basketball shoes.
+ Because the KPI (awareness) is subjective/attitudinal and does not involve any observable online behavior, they agree
+ that the KPI will be measured by surveys, with "lift" being defined as an increase in self-reported awareness among 
+ people who saw the ad, compared to self-reported awareness among people who did not see the ad. 
+ 
+The agency develops a "media plan" which documents their intent to run advertising across 10 different basketball related
+ publications and channels. Some of these channels charge materially more for the same number of ad impressions, so
+ the brand and the agency agree that they'll make a special effort to keep track of which channels are particularly effective
+ and to rebalance spending during the campaign, in line with observed ROI.
+ 
+ At this point, the brand or the agency contracts with a **3rd party measurement vendor** such as Kantar, Nielsen, or Survata
+ who help them set up and conduct measurement and will report on the ongoing and ultimate performance of each channel
+  in the campaign.
+  
+The vendor's core responsibility is to locate and survey a sufficiently large number of "exposed" respondents (who have seen
+  the JumpJetz ad campaign) and "control" respondents (who have not). They must collect a large enough "sample" to allow
+   drawing valid statistical conclusions about the efficacy of the campaign. 
+   Typical successful brand advertising campaigns have effect sizes in the 1-10% range,
+  meaning that hundreds of exposed and control respondents are necessary to muster the "[power](https://en.wikipedia.org/wiki/Power_of_a_test)"
+   to detect statistically significant
+  lift. And if advertisers are interested in "slicing-and-dicing" lift by channels (as they usually are), they must collect
+  a sufficient sample size for each channel individually. Thus the required overall sample size increases significantly.
+  
+### Challenges of Measurement
+  
+  Surveys are expensive to conduct. Most people don't enjoy taking surveys (and the ones who do tend to not be representative
+  of the general population). Unless surveys are extremely brief (e.g. ~1 question), most survey takers must be somehow 
+  remunerated to respond, and the longer surveys are the more remuneration is required. So for measurement to be economically viable, vendors must
+keep surveys as short as possible and recruit only as many respondents as are strictly necessary.
+
+Brand lfit KPI's are inherently idiosyncratic and specific to a particular campaign -- i.e. JumpJetz is interested in 
+increased awareness of JumpJetz specifically, not of basketball shoes in general. So the brand lift vendor needs to locate
+people who have seen a JumpJetz advertisement and give them a survey that asks questions specifically about JumpJetz.
+
+### The Measurement Process
+
+Different vendors have different methods of locating, surveying, and remunerating respondents but they all begin by 
+integrating with the advertiser's (or sometimes publishers') ad servers to track exposure to ad campaigns by placing 
+tracking pixels inside of the advertising unit (usually an iframe). When the ad renders inside a browser, the tracking pixel
+makes a request to the vendor's servers, affording the vendor the opportunity to place their 3rd party cookie in the browser.
+When the ad server composes the HTML of the ad, it fills in "macros" in the URL which allow passing along metadata about the
+exposure, primarily "creative ID's" specifiying which creative asset was shown and "placement ID" specifying which website
+the ad was shown on (and often other contextual information such as whether the ad loaded in a display vs. video slot). 
+The vendor records this exposure, keyed off their own cookie ID and an identifier for the particular campaign being measured. 
+If browser already has a cookie from the vendor, the vendor will increment a counter rather than dropping a new cookie.
+
+In order to actually survey people, the vendor needs these people to later visit a different domain where the actual
+surveys are being conducted (and to elect to actually take a survey). The vast, vast majority of people will never make 
+their way to a survey domain and so will not actually be surveyed. 
+
+In Survata's case, we maintain relationships with a wide network of "4th party" publishers who have agreed to host code
+that produces what we call a "surveywall". Functionally similar to a paywall, the surveywall asks site visitors
+ to take a short survey before proceeding. This gives the user the explicit option to voluntarily trade a small amount 
+ of their time, attention, and opinions for the publisher's valuable content. 
+If the user agrees to take a survey, our surveywall code checks for the presence of a Survata cookie and, if found, sends the cookie ID to our servers. We 
+cross reference our tracking data to see if which (if any) ad campaigns the user's browser has been exposed to. (**This 
+"check the cookie and select a survey" step is probably the single most crucial step in the entire measurement process.**
+ Without our 3rd party cookie and the recorded ad exposure information attached to it, we would have no way of knowing which, if any, survey 
+  is suitable to give to this respondent).
+
+When we recognize that a user visiting our surveywall has seen the JumpJetz campaign, we give them a brief survey asking questions 
+such as "When you think of basketball shoes, what brands come to mind?" or "which of the following brands of basketball shoes
+are you aware of? (Nike, Reebok, JumpJetz)". Our servers record the survey answers and when the survey is complete the 
+user is given access to the publisher's content. If this user hasn't seen the JumpJetz campaign, we may give them a 
+different survey for a different campaign they have seen, or we may collect them as an unexposed "control" response.
+
+Survata does not collect (nor would we want to collect) any
+personally identifiable information (e.g. we do not ask for emails in our surveys). The only information we collect 
+is 1) survey responses themselves and 2) the exposure history, keyed to a randomly generated cookie ID, which we only use
+for survey qualification and post-hoc aggregation of results by channel. 
+ 
+Survata charges the advertisers for measurement, and pays a portion
+of the fee we collect through to the publisher for each survey response they produce. (This flow of money helps fund
+a section of the web which provides content which is too valuable to be funded by advertising, but in many cases
+not valuable enough to meet minimum charge size thresholds for credit card payments). 
+
+### Providing the Results
+Once we've collected enough responses for a campaign, we begin a statistical analysis of the results. 
+
+We report our aggregated results to brands and agencies, and use the exposure metadata 
+(placement and creative IDs) to break the impact down by the publisher where the ad ran, the different creatives in the 
+campaign, the ad format (e.g. video vs. banner), and any other recorded attributes of interest.
+
+Crucially, **the "end product" of brand lift measurement is inherently statistical and aggregated**. The final reporting
+contain results like "Awareness increased by 4% on average among everyone who saw the ad." and "Video ads produced a 
+greater increase in awareness (7%) than banner ads (3%)." The particular survey answers
+and ad exposure history of particular respondents is of no interest to brands or agencies. The 
+**only** reason exposure history is collected at all is so that surveys can be correctly targeted to relevant respondents,
+and so that aggregate performance conclusions can be drawn (e.g. that JumpJetz ads run on ESPN were more effective than the ads run on Vox).
+
+# Conclusion
+If browsers can provide API's that allow targeting surveys to exposed/control respondents and allow post-hoc aggregations 
+and analysis by channel, then measurement vendors (or at least Survata) would be more than happy to abandon any reliance
+on third party cookies or cross-site tracking.
+
+# Appendices
+
+If, by now, you've accepted the premise that 3rd party, neutral brand lift measurement needs to be preserved then you likely
+don't need to read any further.
+
+The remainder of this document goes into detail about the consequences (to the web) of breaking brand lift measurement,
+then discusses potential current alternative methods of brand lift measurement that don't require 3rd party cookies (and why those alternatives are not viable),
+and then discusses potential unintended consequences whereby well-intentioned efforts to preserve user privacy might
+inadvertently promote the growth of a new competing ecosystem with substantially worse privacy characteristics.
+
+## Implications of the loss of third party cookies
+ 
+As discussed above, measurement vendors use (their own) third party cookies to record particular browsers' histories
+of exposure to the ad campaigns they're measuring. They need this history for one crucial reason - when they're
+later given an opportunity to survey the users of those browsers, they need to know which survey to give to which person
+(and whether that person should be counted as an "exposed" or a "control" in the statistical analysis). This step
+is unfortunately indispensable to the entire third party measurement process. There is no viable way to measure the 
+efficacy of most types of brand advertising without surveys, and there is currently no way to conduct the necessary
+surveys without third party cookies.
+
+In addition to "survey qualification", the exposure metadata that is transmitted along with each impression (keyed
+off the cookie ID) is extremely useful for allowing advertisers to understand which parts of their campaigns are
+under or over-performing. For example, it allows them to understand the relative efficacy of different channels
+(e.g. one publisher vs. another, or banner ads vs. video ads).
+ 
+If the measurement vendors' cookies are blocked by the browser (and alternative APIs are not provided), there will be 
+no viable way for advertisers to measure the efficacy of their campaigns or to calculate any form of meaningful return
+on advertising spending. As discussed above, channels which become unmeasurable are likely to wither as advertising
+spending flees to channels that remain measurable.
+  
+Brand advertisers currently spends heavily on the open web, but they use other channels as well. In particular, brand advertising
+also happens within "owned and operated" platforms like Facebook, as well as within mobile apps and through connected and
+"[addressable](https://simpli.fi/addressable-tv-vs-addressable-ott-ctv-bringing-precision-to-addressable-advertising-in-2020/)" television. Most measurement
+vendors also measure some or all of these channels in addition to measuring the web.
+
+Without effective 3rd party brand measurement options, brands advertisers will be forced to choose between conducting unmeasurable 
+advertising on the open web vs. easily measurable advertising in mobile apps, on CTV, or in walled garden social platforms. 
+ Many advertisers will choose to pull their (very material) spending from the open
+web and double down on apps, TV, and platforms. Journalists and others producing content for the open web are already
+struggling enormously to remain economically viable. If their advertising revenue is slashed, then the only types of 
+content that will remain economically to produce on the open web will be content that draws such enormous audiences that
+it can survive off low, un-targeted CPM's, or content that it is narrow and specific to "high-value" contexts where contextual 
+advertising is valuable. Huge
+swaths of the freely available information that makes the web so wonderful do not meet either criterion and will be unlikely to survive.
+ 
+## Potential alternatives to the current system
+ 
+ Although using neutral third parties is the predominant method of measuring brand advertising, it is not strictly the 
+ only option. This section discusses some alternatives (and explains why they do not satisfy the goal of adequately
+ supporting a healthy, private web).
+ 
+### 1st party measurement
+ 
+ Even if third party cookies disappear, first party cookies are presumably safe. So one option is to require that the 
+ domains where advertising is served also conduct (or at least host) the surveys used to measure that advertising. This 
+ may sound attractive, since it supports the goal of never requiring one domain to know about activities on other domains.
+ And in fact 1st party measurement does happen today -- Facebook, Twitter, YouTube (and most likely others) all 
+ currently insert brand lift surveys into their content feeds and are thus able to estimate brand lift effects among people
+ exposed to ad campaigns on their sites.
+ 
+ This system has several problems:
+ 
+ 1. Platforms are only able to estimate effects within their own channels, but most brand advertising campaigns are 
+ conducted across many channels simultaneously. 1st party vendors do not adhere to common standard for how effects
+ are measured or reported, meaning that advertisers are left to piece together self-reported effects across multiple channels
+ which are often provided in incommensurable units or over incompatible time periods.
+ 2. 1st party measurement is only technically feasible for very large publishers:
+    1.  In-platform surveys require substantial scale. Brand advertising campaigns tend to be spread widely across
+     many different publishers. It is already difficult for brand lift vendors to collect enough respondents for campaigns
+     with less than ~10m impressions. Even when they can, they are often only able to get an "overall" read that consolidates 
+     across publishers. If each publisher must measure itself individually, many publishers will not serve enough ad impressions
+     to be able to yield enough survey responses for a meaningful read. Many smaller ad campaigns will become completely
+     impossible to measure. And advertisers will start having a perverse incentive to concentrate their ad spending 
+     across fewer publishers (in hopes of getting to "reportable" sample on at least some of them). Larger publishers
+     are more likely than small ones to survive this consolidation.
+    2. In-platform surveys require substantial repeat traffic -- a large number of people who 
+    saw an ad at T0 must return to the platform (and agree to take a survey) within a sufficiently short time window 
+    to allow measuring the brand effects before they wear off (many brand advertisers believe effects fade dramatically by T+30 days). 
+    Repeat traffic is not a problem for high-usage sites like YouTube but is a substantial problem for sites providing 
+    e.g. long-form journalism, which visitors might only visit a few times per year. 
+    3. Building and operating an in-site survey system is a substantial technical challenge. 
+    Facebook can afford to employ a team of engineers and survey statisticians to develop and operate a 1st party measurement system,
+     but the large majority of longer-tail publishers cannot. 
+ 3. No matter how well-intentioned the platforms conducting 1st party measurement are, there is a **strong** business 
+ incentive not to provide fair, neutral measurement (especially if publishers are relieved of any possibility of "replication"
+ by neutral third parties). Advertisers are actively searching for sites with low ad performance so they can cut spending
+ on those sites. It is injudicious to rely on publishers to "grade their own homework" when giving themselves a poor 
+ grade **directly** leads to a substantial loss of revenue.
+ 
+ First party measurement is useful in itself and it can and should continue to complement neutral, third party measurement. But it cannot
+ replace third party measurement. Moreover, the insurmountable obstacles to replacing third party measurement are social and economic,
+ not technical. Therefore, it is highly unlikely that *any* technological innovation could make first party measurement
+ a self-sufficient option.
+ 
+### Spray-and-pray surveys
+ 
+ As discussed above, vendors use third party cookies for selecting which survey to show to which people (and for categorizing
+ respondents as "exposed" vs "control"). Strictly speaking, it's not technologically necessary to select specific surveys 
+ for specific people. It *is* necessary to ask questions that are idiosyncratic to the brands being measured, but in theory
+ vendors could survey a large number of completely random people and ask them questions like "Have you heard of JumpJetz sneakers?"
+ regardless of whether they're expected to have seen a JumpJetz ad. Vendors would still need a way of separating exposed
+ vs control respondents, but this could be done by asking "opportunity to see" type questions such as "did you visit ESPN.com
+ in the last 7 days".
+ 
+ While such a "spray-and-pray" system would have excellent privacy characteristics (it would not collect any information
+ at all on respondents beyond what they explicitly volunteer), it suffers from enormous economic problems.
+ 
+ Particularly, a spray-and-pray system would have to **enormously** increase the volume of survey responses collected. Survata
+ measures many ad campaigns that serve ~10 million or fewer total ad impressions. Some of these impressions go to the same devices, so
+ the total number of unique devices reached might be as low as ~5 million. For a USA-only ad campaign, that would
+  mean that only approximately 1.5% of the US population would have been exposed to an ad. This would mean that to collect an
+  equivalent number of respondents as one would collect via targeted surveys, one would need to collect ~64 times as many respondents.
+  I.e. to collect 10,000 exposed respondents, one would need to conduct 640,000 surveys (i.e. roughly the entire population of
+  Portland). As discussed above, survey responses are expensive to collect so this increase in scale would multiply the cost of 
+  measuring a campaign by 64 times (or probably more, because with such enormous sample sizes required, the marginal respondent
+  would grow more and more expensive to acquire). These increased costs would most likely totally swamp any economic benefit advertisers could
+  hope to derive from measuring their campaigns (and so they'd simply opt instead to advertise through channels which are
+  economical to measure).
+  
+Even putting aside raw collection costs, "opportunity to see" metrics have substantial statistical problems. The primary
+issues are that 1) people have poor memories and 2) many people who have the opportunity to see an ad will nevertheless
+not see it *especially* when ads are highly targeted as online ads typically are. The result is that many people will 
+report not having had the opportunity to see an ad even though they did (thus being incorrectly marked as a "control"),
+and many people who report having had the opportunity will be incorrect or will otherwise not have seen it (thus being
+incorrectly marked as an "exposed"). 
+
+"Muddying the waters" by including many mislabled respondents has the primary effect of diluting observed effects, leading
+to an understatement (potentially a substantial understatement) of the effectiveness of brand advertising on the open web.
+These effects can be adjusted for *if* statisticians know the "ground truth" misclassification rates, but there is no way
+to assess those rates without 3rd party cookies. Thus advertising on the open web would appear materially less effective
+than advertising through other channels (e.g. apps) that are still able to accurately measure undiluted lift.
+
+For both economic and statistical reasons, spray-and-pray surveying is not a viable alternative. If brand measurement is
+to continue (which is necessary for brand advertising on the open web in general to continue) it must remain possible to
+target surveys to the appropriate potential respondents.  
+ 
+## Further technical details
+ 
+ This document has already gotten very long, but please file an issue or contact george@survata.com if you'd like any additional
+ details about any topics in this document.

--- a/support_for_advertising_use_cases.md
+++ b/support_for_advertising_use_cases.md
@@ -16,19 +16,42 @@ This document is broken down into 4 main sections based on the needs of the vari
 
 ## Basic Advertiser Needs
 
+All advertising aims to drive an outcome. There are many types of desirable outcomes, and these outcomes differ along several key axes:
+
+1. **Immediate vs delayed**: signing up to be an Uber driver right now,
+vs. remembering to consider a Mercedes next time they're buying a car
+2. **Actions vs. Attidues**: taking a specific action like dialing a lawyer's office vs.
+just remembering to "Think Different"
+3. **Direct vs. Indirect**: buying glasses directly from warbyparker.com, vs. buying Ray-Ban's from their
+ local optician after seeing a Youtube ad
+ 
+Outcomes that are immediate, direct actions are typically referred to as "conversions" and the type of
+advertising that prioritizes conversions is typically called "direct response advertising." Conversely, advertising that
+focuses on outcomes that involve a change in attitudes or involve actions that are delayed (and often indirect) is typically called "brand advertising." 
+
+(Please see the document on [Advertising Outcomes](advertising-outcomes.md) in this repo for a list of more potential outcomes.)
+
+Both types of advertising are prevalent on the internet, and many ad campaigns by larger advertisers include a blend of
+ both types. Direct response advertising represents the majority of digital advertising, but in recent years 
+ spending on digital brand advertising has grown rapidly, particularly on premium publishers like the Washington Post and The New York Times.
+ Some channels, like paid search, are dominated by direct response advertising. Others, like online video, are dominated by brand advertising. 
+
 When an advertiser spends money to run an ad campaign they want to answer three very basic questions about it:
-- How many people saw the ad?
-- How many conversions happened as a result of running this ad campaign?
+- How many people saw the ad? Was the ad visible, and was it shown to the people I intended to see it?
+- How successful was the campaign at driving the desired outcomes/conversions?
 - Are you confident that the ad impressions and ad conversions are from real, authentic people?
 
-Although they sound like simple questions, in practice answering them well is rather complex and difficult undertaking. The ads industry has endeavored to find good ways of answering these basic questions, and has developed a number of approaches to doing so, which is why there are more than 3 use-cases in this section.
+Although they sound like simple questions, in practice answering them well is a rather complex and difficult undertaking. 
+The ads industry has endeavored to find good ways of answering these basic questions, and has developed a number of approaches to doing so, which is why there are more than 3 use-cases in this section.
 
 - [Impression and Viewability Measurement](#impression-and-viewability-measurement)
   - [Viewability](#viewability)
   - [Invalid Traffic](#invalid-traffic)
   - [Third Party Verification](#third-party-verification)
+  - [Audience Verification](#audience-verification)
 - [Aggregate Conversion Measurement](#aggregate-conversion-measurement)
-  - [Lift Measurement](#lift-measurement)
+  - [Conversion Lift Measurement](#conversion-lift-measurement)
+  - [Brand Lift Measurement](#brand-lift-measurement)
   - [Click-through and View-through attribution heuristics](#click-through-and-view-through-attribution-heuristics)
   - [Multi-touch attribution](#multi-touch-attribution)
   - [Cross Browser / Cross Device Measurement](#cross-browser--cross-device-measurement)
@@ -41,8 +64,10 @@ Although they sound like simple questions, in practice answering them well is ra
   
 | Use-case | Chrome | Safari | Community Proposals |
 |----------|--------|--------|---------------------|
-| [Impression and Viewability Measurement](#impression-and-viewability-measurement) | There should be no conflict with Chrome’s proposed “[Privacy Model for the Web](https://github.com/michaelkleber/privacy-model)”. First parties should still be capable of measuring that the ads displayed on their own properties entered the viewport, that images and video were loaded, how much time they spent in the viewport, etc. None of this requires joining up user identity across multiple domains. The only possible complication that might arise would be with "blind rendering" as described in proposals like "[TURTLEDOVE](https://github.com/michaelkleber/turtledove)" and “[PETREL](https://github.com/w3c/web-advertising/blob/master/PETREL.md)”. Here, the publisher would have restricted access to the ad being rendered and we will have to discuss the feasibility of "viewability" measurement. There is a discussion on this [GitHub issue](https://github.com/csharrison/aggregate-reporting-api/issues/10). | Similar answer as that for Chrome. This should not be in conflict with Webkit's [Tracking Prevention Policy](https://webkit.org/tracking-prevention-policy/) given the measurement is entirely within the scope of a single publisher website. | | 
-| [Lift Measurement](#lift-measurement) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions, which should be sufficient to support lift measurement using experiments on a first party site (e.g. when using a first-party identifier to decide which experiment branch a person is in). | No support | Facebook proposal for “[Private Lift Measurement](https://github.com/w3c/web-advertising/blob/master/private-lift-measurement-conceptual-overview.md)” |
+| [Impression and Viewability Measurement](#impression-and-viewability-measurement) | There should be no conflict with Chrome’s proposed “[Privacy Model for the Web](https://github.com/michaelkleber/privacy-model)”. First parties should still be capable of measuring that the ads displayed on their own properties entered the viewport, that images and video were loaded, how much time they spent in the viewport, etc. None of this requires joining up user identity across multiple domains. The only possible complication that might arise would be with "blind rendering" as described in proposals like "[TURTLEDOVE](https://github.com/michaelkleber/turtledove)" and “[PETREL](https://github.com/w3c/web-advertising/blob/master/PETREL.md)”. Here, the publisher would have restricted access to the ad being rendered and we will have to discuss the feasibility of "viewability" measurement. There is a discussion on this [GitHub issue](https://github.com/csharrison/aggregate-reporting-api/issues/10). | Similar answer as that for Chrome. This should not be in conflict with Webkit's [Tracking Prevention Policy](https://webkit.org/tracking-prevention-policy/) given the measurement is entirely within the scope of a single publisher website. | |
+| [Audience Verification](#audience-verification) | No support | No support | No Support | |
+| [Conversion Lift Measurement](#conversion-lift-measurement) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions, which should be sufficient to support lift measurement using experiments on a first party site (e.g. when using a first-party identifier to decide which experiment branch a person is in). | No support | Facebook proposal for “[Private Lift Measurement](https://github.com/w3c/web-advertising/blob/master/private-lift-measurement-conceptual-overview.md)” |
+| [Brand Lift Measurement](#brand-lift-measurement) | No support | No support | No support | |
 | [Click-through attribution](#click-through-and-view-through-attribution-heuristics) | Proposal: “[Click Through Conversion-Measurement Event-level API](https://github.com/WICG/conversion-measurement-api)” | Proposal: “[Private Click Measurement API](https://github.com/WICG/ad-click-attribution)” |
 | [View-through attribution](#click-through-and-view-through-attribution-heuristics) | A [section of the Conversion Measurement with Aggregation proposal](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#view-through-conversions) describes explicit support for view through conversions. | No support | |
 | [Multi-touch attribution](#multi-touch-attribution) | The [Event-level API](https://github.com/WICG/conversion-measurement-api/blob/master/README.md) proposal covers last-click attribution.  A section of the [Conversion Measurement with Aggregation](https://github.com/WICG/conversion-measurement-api/blob/master/AGGREGATE.md#multi-touch-attribution-mta) proposal describes support for some built-in multi-touch models, and acknowledges that measurement providers writing their own models would be good to support if technically feasible. | No support | Facebook proposal for “[Privacy-Preserving Multi-Touch-Attribution and Cross-Publisher Lift Measurement](https://github.com/w3c/web-advertising/blob/master/privacy_preserving_multi_touch_attribution_and_cross_publisher_lift_measurement.md)” |
@@ -154,15 +179,72 @@ These use-cases are more focused on the publisher's perspective.
 
 Advertisers need to know how many conversions happened as a result of their ad campaigns. 
 
-## Lift Measurement
+## Conversion Lift Measurement
 
 Ideally advertisers would like to know how many conversions were caused by their ad campaign (i.e. would not have happened were it not for this ad campaign). This is variously refered to as "causality" or "incrementality" measurement. The gold standard measurement approach to answer this question is “Lift Measurement”. This involves a “test group” who is shown ads, and a “control group” who is not shown ads. These groups should be randomly selected prior to running the test to ensure they are well balanced. 
 
 The total number of raw conversion events is counted in both groups, and the difference between the two is called the “lift”. If this is a statistically significant value, and the test and control groups were selected randomly, the only explanation for the difference is the causal effect of the ads.
 
+## Brand Lift Measurement
+
+Much like direct response advertisers want to know how many incremental conversions were caused by their ad campaigns, 
+brand advertisers want to know whether their ad campaigns succeeded in making consumers incrementally more aware of, interested in, or
+favorable towards their brand, product, or service.
+
+Because these attitudinal outcomes are not linked to a discrete observable action (like an online purchase), they typically 
+must instead be measured through surveys that ask questions like "to what extent do you believe
+that Volvo makes the safest cars on the market?"
+
+Lift is measured by comparing the prevalence of a given answer among an "exposed" group of respondents who have seen a 
+particular ad campaign compared to the prevalence of that same answer among a control group who have not seen the campaign.
+
+Measuring brand lift adds substantial challenges beyond those already involved in measuring conversion lift:
+ 
+ 1. Brand advertising rarely produces clicks (or any other direct interaction with the ad unit). For example, video advertising - the [fastest growing online ad 
+ format](https://www.iab.com/wp-content/uploads/2019/10/IAB-HY19-Internet-Advertising-Revenue-Report.pdf) - is almost all intended to drive brand outcomes (like awareness), not clicks. This means that any browser API that requires
+ clicks to operate will not be suitable for Brand Lift Measurement (though API's that support "view-through conversions" 
+ may potentially be sufficient).    
+ 2. Attitudes towards Toyota are fundamentally different than attitudes towards BMW, and so a Toyota 
+ad campaign can only be measured by a survey that specifically asks about attitudes towards Toyota in particular. Because surveys 
+are expensive to administer, it would be uneconomical to survey hundreds of thousands of consumers about their attitudes
+ towards every car brand, hoping that enough of them turn out to have seen a Toyota ad. Instead, surveys must be 
+kept brief and must be narrowly targeted to people who have seen *specific* ad campaigns (or are in a control group with respect
+to that particular ad campaign).
+
+The necessity of targeting specific surveys to particular respondents means that at some point, some system must select
+the right survey to show to a particular person. And that decision can only be based on that person's past exposure
+(or non-exposure) to particular ads. This selection may not be a privacy problem in 1st party contexts where a particular publisher running
+an on-site survey just needs to record which ads a particular user has seen on that 1st party domain. (Though that itself 
+might be a problem if publishers are blinded to the ads served via a system like TURTLEDOVE).
+
+While some large publishers (e.g. Youtube) do conduct their own brand measurement surveys in a 1st party context,
+advertisers are understandably reluctant to allow publishers to "grade their own homework." Also, the vast majority of 
+brand campaigns are conducted on many different channels simultaneously. Conducting and analyzing surveys requires expertise
+ that is unrealistic for small, independent publishers to develop and deploy on their own. Thus the large majority of                                                               brand lift measurement is conducted via 3rd party channels (either by intercepting visitors on other websites, or by
+using 3rd party panels).
+
+When surveys are conducted on a different domain than the original ad exposure, the surveying domain must have some way
+to select the right survey to give based on the respondent's ad exposure profile across other domains.
+
+Fortunately, the conclusions of attitudinal brand lift measurement are inherently statistical and aggregated, e.g. "this campaign increased awareness by 
+10% among those who saw it". The responses of any individual are irrelevant beyond their contribution to a summary statistic.
+ If a privacy-safe way to collect and aggregate the the survey data can be devised, measurement providers have no 
+ further need to retain any information about individuals. 
+ 
+ Brand lift measurement does have some additional privacy advantages:
+ 
+* It is inherently opt-in, because surveys used to measure attitudes are inherently optional. Consumers
+ who do not wish to have their reactions to brand advertising measured can simply choose not to respond to surveys.
+* Although 3rd party brand lift measurement does require some degree of aggregation of cross-site behavior, it does
+**not** require the advertiser, the publisher, or the measurement company to collect and share any personally 
+identifiable information about about people whose attitudes are being measured.     
+* Knowing which survey to administer to a browser does not inherently require any browser-level identification. Vendors
+ only need to know the campaign or creative-level exposure attribute (which is shared by thousands or millions of 
+ other browsers). I.e. vendors only need to know about membership in groups that are always very large.
+
 ## Click-through and View-through attribution heuristics
 
-The alternative approach is to use some heuristic to “attribute” conversions to ads. The two most popular heuristics are “click-through attribution” and “view-through attribution”. “Click-through attribution” gives credit to an ad if the person had previously clicked on the ad prior to the conversion event. “View-through attribution” gives credit to an ad if the person had previously seen the ad prior to the conversion event.
+The alternative to lift measurement is to use some heuristic to “attribute” conversions to ads. The two most popular heuristics are “click-through attribution” and “view-through attribution”. “Click-through attribution” gives credit to an ad if the person had previously clicked on the ad prior to the conversion event. “View-through attribution” gives credit to an ad if the person had previously seen the ad prior to the conversion event.
 
 Both attribution heuristics come with some concept of an “attribution window”. For example, a “one-day view-through” attribution window would only count conversions which happened within one day of an ad view. A “28-day click-through” attribution window would only count conversions which happened within 28 days of a click.
 
@@ -303,7 +385,7 @@ There are a few critically important aspects of impression counting that adverti
 
 Sometimes, an ad is returned from an ad-server, but never actually enters the viewport. Sometimes an ad might enter the viewport, but only for a few milliseconds. Sometimes an ad might enter the viewport, but fail to load any images or video before it leaves again. Sometimes there might be other elements drawn over the top of the ad. These cases illustrate "non-viewable" ad impressions. Advertisers only want to pay for "viewable ad impressions". The reasoning is simple, an ad cannot possibly have an effect on someone's future purchasing behavior if they never saw it in the first place!
 
-Over the years, the industry has developed standards to define what consititues a "Viewable ad impression". These are different for image and video ads, for the mobile and desktop web, and in-app. Industry bodies like the IAB and the MRC regularly audit measurement vendors (ad servers, ad verification vendors) to see if they are compliant with these standards.
+Over the years, the industry has developed standards to define what constitutes a "Viewable ad impression". These are different for image and video ads, for the mobile and desktop web, and in-app. Industry bodies like the IAB and the MRC regularly audit measurement vendors (ad servers, ad verification vendors) to see if they are compliant with these standards.
 
 ## Invalid Traffic
 
@@ -313,6 +395,54 @@ Advertisers want to show ads to humans, not to bots and scripts. The industry ha
 
 When a measurement vendor (ad server, publisher, etc) reports a certain number of impressions (presumably viewable impressions, with invalid traffic filtered out), how is the advertiser to know if this number is accurate? Advertisers would prefer not to just accept these numbers on faith. For this reason, the industry has established a number of independent, third-party measurement vendors that run their own verification scripts to provide advertisers with the peace of mind and confidence that the number of impressions they are being billed for are accurate, and measured in a consistent way across all of their ad buys.
 
+# Audience Verification
+
+Not all products are suited for all consumers. For example, in the United States sales of alcohol are restricted to 
+people age 21 and over, and there are even regulations limiting the extent to which advertisements for alcohol can be 
+shown to people under 21. Thus advertisers of alcohol have not only an economic interest but also a legal obligation
+to avoid advertising to teenagers.
+
+The current ecosystem has developed elaborate mechanisms to allow advertisers to reach consumers they believe will 
+have the interest and ability to purchase their products. While the move to a more private web will (and should) 
+eliminate some of the current privacy-unfriendly techniques marketers use for targeting, it will not eliminate 
+the reasonable desire (and in some cases obligation) to avoid showing irrelevant ads to uninterested or inappropriate 
+consumers.  
+
+There is a real cost in assembling and assessing addressable audiences who are united by some common characteristic of 
+interest. As such, vendors who amass these audiences (whether those vendors are 
+publishers or third parties) often charge a substantial premium to advertisers who wish to access these audiences.
+ With so much money at stake, advertisers have a strong 
+ interest in knowing whether they're actually reaching the types of people they're paying to reach. As targeting moves 
+ behind opaque mechanisms like TURTLEDOVE, there is a real risk that without the possibility of independent 
+ verification, advertisers lose so much trust in the accuracy of audience targeting mechanisms that they revert 
+ to the inefficient and annoying-to-consumers spray-and-pray tactics of the mass media era. This will both hurt
+  consumers who will be bombarded with irrelevant or lowest-common-denominator ads, and it will hurt small publishers 
+  for whom providing advertisers access to a niche audience may be their primary economic value proposition. 
+ 
+As with lift measurement, the conclusions marketers are aiming to draw are inherently statistical, aggregated, and 
+ privacy-friendly. Advertisers are not interested in learning or retaining the demographics of any particular ad viewer -
+ they only want to know that e.g. "95% of people who saw my ad were over the age of 21."
+ 
+Some publishers have demographic information on their users and are able to report viewership
+demographics based on 1st party data. But the vast majority of publishers do not know the demographics of their viewers,
+even of viewers who are registered or subscribed. Thus advertisers use products like Nielsen's "Digital Ad Ratings" and
+ rely on Nielsen to track ad campaigns and survey people who've seen ads to collect age and gender statistics. 
+ 
+ While age and gender are the most commonly measured attributes, advertisers also often want to target audiences based on 
+ finer-grained demographics (e.g. people who live in St. Louis) or interests (e.g. "people who play golf"). 
+ 
+ The data used for audience measurement can come from different sources, but particularly for finer-grained attributes
+ surveys often provide the most accurate (or sometimes the only) way of assessing attribute prevalence among the people
+  exposed to a campaign. As is the case with [Brand Lift Measurement](#brand-lift-measurement),
+   these surveys which must be conducted at some point after the advertising itself is displayed. 
+   The data can neither be inferred from the rendering of the advertisement (as e.g. viewability can) nor
+ can it be collected contemporaneously with the exposure. This means that the vendor conducting the surveys must have some way to know which
+  advertising campaigns individuals have been exposed to in order to ask the right survey questions and to 
+  properly aggregate the responses. Asynchronous 
+  reporting API's may play a part in supporting the audience verification use-case but they are not themselves sufficient,
+  because it's not plausible to ask every potential question about demographics and interests to every respondent. So
+  surveys need to be targeted to the relevant groups of advertising-exposed respondents.
+  
 # Brand Safety
 
 Some web-pages may contain graphic imagery, or might discuss controversial topics, or include news about disaster or tragedy. Advertisers care a great deal about the types of concepts that people will associate with their brand. For this reason, advertisers might not feel comfortable having their advertisements run alongside these types of content.


### PR DESCRIPTION
# Overview

Brand advertising provides a substantial fraction of the revenue that supports the open web. Brand advertisers rely on being able to measure the efficacy of their advertising in order to justify continuing their spending.

The deprecation of third party cookies is poised to break effectively all reliable measurement of brand lift on the web. A new set of privacy-preserving, measurement-facilitating APIs will be necessary if brand advertisers are to be allowed to continue measuring ad efficacy. Without reliable measurement options, brand advertising will pull spending from the web and reallocate it to more measurable platforms like mobile apps and connected TV.

I work at Survata, a vendor that offers brand lift measurement. To the best of Survata's understanding, none of the currently proposed API's in Chrome's "privacy sandbox" are sufficient to allow brand lift measurement on the web. At this time, we do not have any solutions to suggest. But we are able to share our experiences and to provide a thorough discussion of:

* brand advertising,
* the brand lift measurement "use case", 
* why that use case is important to the health of the web, 
* a detailed overview of how brand lift measurement is currently conducted,
* an explanation of how the removal of 3rd party cookies will break the current process.

Our hope is that this PR can be the opening step of a broader discussion about how to support brand lift measurement within a more private web. 

# Contents

1. Additions/edits to the [Advertising 101](advertising101.md) document, providing a high-level introduction to what brand advertising is, how it's different from direct response (i.e. click/conversion-focused) advertising, and why brand advertising is a major economic supporter of the open web.
2. An addition to the [Support for Use Cases](support_for_advertising_use_cases.md) document, providing a summary of brand advertising measurement, an explanation of why measurement is important to maintaining brand advertising's spending on the web, and a high-level discussion of what measurement requires and why eliminating 3rd party cookies will break it. 
3. A [list of the outcomes](advertising-outcomes.md) that advertising aims to achieve (particularly outcomes that are not tied to clicks or conversions). 
4. A deeper dive into the [mechanics of brand lift measurement](brand_lift_overview.md), which provides a detailed walkthrough of the brand lift measurement process. It explains concretely how brand lift measurement currently uses 3rd party cookies (and why there are currently no alternatives to that usage). This document aims to help establish a clear set of "requirements" that will be necessary in order for new private APIs to support brand lift measurement.

We recommend reading the documents/changes in the above order.

We welcome any comments/suggestions/questions.