### PR TITLE
Re-position Success Criteria on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Raise issues, add drafts. As you add a document, feel free to add a PR for its d
 * [Self-Review Questionnaire: Interoperability, Choice, Accessibility and Accountability](interoperability-choice-accessibility-accountability-questionairre.md)
 * [Frequency Capping and Frequency Optimization](frequency-capping-and-optimization.md)
 * [Privacy Preserving Multi-Channel Attribution](privacy-preserving-multi-channel-attribution.md)
+* [Proposed Success Criteria](success-criteria.md), this document defines success criteria to consider when evaluating proposals which impact web advertising.
 
 # Ideas and Proposals (links outside this repo)
 * [Private fraud prevention](https://github.com/siyengar/private-fraud-prevention)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Raise issues, add drafts. As you add a document, feel free to add a PR for its d
 # Introductory and Summary Material
 
 * [Advertising Technology Use Cases](support_for_advertising_use_cases.md): "Use Cases" Tabulation of common AdTech use cases and the proposals or browsers supporting them
-* [Success Criteria](success-criteria.md), this document defines success criteria to consider when evaluating proposals which impact web advertising.
 * [Overview of Online Advertising & Marketing](advertising101.md), an overview of common business use cases for digital advertising.
 * [Participants in Online Advertising](OnlineAdvertisingParticipants.md) "Hello Ads," an introduction to the online advertising ecosystem.
 * [Common User Flows](common-user-flows-in-web-advertising.md): Example user experiences and the parties involved.


### PR DESCRIPTION
The Success Criteria document has been much debated and disputed. At some point it became the core document in a discussion around a different group and procedures elsewhere in the W3C. To avoid confusion, I propose we remove it from the front readme. We can retain the document for future reference and discussion, however, at this time I think we've moved on from it and it no longer fully represents the context of what this group aims to do. 