### PR TITLE
Adding a list of useful readings to help participants understand privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Raise issues, add drafts. As you add a document, feel free to add a PR for its d
 * [Overview of Online Advertising & Marketing](advertising101.md), an overview of common business use cases for digital advertising.
 * [Participants in Online Advertising](OnlineAdvertisingParticipants.md) "Hello Ads," an introduction to the online advertising ecosystem.
 * [Common User Flows](common-user-flows-in-web-advertising.md): Example user experiences and the parties involved.
+* [Understanding Privacy Advocates](understanding-privacy-advocates.md): a set of readings to help understand the position of privacy and user advocates to help address them in our proposals.
 
 # Testing Opportunities
 

--- a/understanding-privacy-advocates.md
+++ b/understanding-privacy-advocates.md
@@ -46,3 +46,4 @@ Please make additions to this list at the bottom of the appropriate section.
 
 - [Privacy in Context](https://www.amazon.com/Privacy-Context-Technology-Policy-Integrity/dp/0804752370)
 - [Subprime Attention Crisis](https://us.macmillan.com/books/9780374538651)
+- [Privacy is Power](https://www.penguin.co.uk/authors/1086495/carissa-veliz.html)

--- a/understanding-privacy-advocates.md
+++ b/understanding-privacy-advocates.md
@@ -1,0 +1,48 @@
+# Understanding Privacy Advocates
+
+The following list is a set of recommended readings and viewings that can help participants understand the position of privacy advocates when they object to the current state of advertising technology. The goal of this document is not to be a comprehensive set of all such possible readings or to claim to represent all privacy advocates, instead it aims to help participants understand a broad overview of concerns and potential societal impacts.
+
+This is not required reading, but where we discuss proposals intended to enhance user privacy it helps to understand what issues user advocates bring forward, not just as a set of engineering requirements, but as a set of concerns, fears, and actual observed harms. The intended outcome is to represent privacy advocates who are metaphorical gorillas in the standards discussion room, concerns we attempt to work in awareness of but are not often represented by the concerned parties because of the technical nature of our discussions. The categories are ordered on theoretical accessibility to our participants. Ordering is not intended to denote importance. 
+
+Please make additions to this list at the bottom of the appropriate section. 
+
+## Specifications 
+
+- [Privacy Threat Model](https://w3cping.github.io/privacy-threat-model/)
+- [Principles of User Privacy](https://darobin.github.io/pup/)
+
+## Videos 
+
+- [Data | Philosophy Tube](https://www.youtube.com/watch?v=fCUTX1jurJ4)
+
+## Reporting 
+
+- [The High Privacy Cost of a "Free" Website | The Markup](https://themarkup.org/blacklight/2020/09/22/blacklight-tracking-advertisers-digital-privacy-sensitive-websites)
+- [It Doesn't Matter who owns TikTok](https://gizmodo.com/it-doesn-t-matter-who-owns-tiktok-1844595163)
+- [This Devious--And Mostly Legal--Ad Scam is Bleeding Small Businesses Dry](https://gizmodo.com/this-devious-and-mostly-legal-ad-scam-is-bleeding-small-1844633313)
+- [Your Phone Is a Goldmine of Hidden Data for Cops. Here's How to Fight Back](https://gizmodo.com/your-phone-is-a-goldmine-of-hidden-data-for-cops-heres-1843817740)
+- [Federal Agencies Use Cellphone Location Data for Immigration Enforcement](https://www.wsj.com/articles/federal-agencies-use-cellphone-location-data-for-immigration-enforcement-11581078600)
+- [Inside the Industry That Unmasks People at Scale](https://www.vice.com/en/article/epnmvz/industry-unmasks-at-scale-maid-to-pii)
+- [Targeted ads isolate and divide us even when they're not political – new research](https://theconversation.com/targeted-ads-isolate-and-divide-us-even-when-theyre-not-political-new-research-163669)
+- [Shareholder Pressure Could Help Defund Misinformation](https://www.adweek.com/programmatic/investors-want-proof-digital-ads-funding-misinformation/)
+- [You Anon: Reconsidering Pseudonymity and what it means to "be yourself" online](https://www.nytimes.com/2021/07/31/style/anonymity-pseudonymity-online-identity.html)
+
+## Blog posts
+
+- [Privacy: A Quick Reality Check](https://berjon.com/privacy-reality-check/)
+- [Protecting cancer victims from adtech](https://bokonads.com/medical-targeting-should-be-illegal/)
+- [The Subprime Ad Crisis is Here](https://medium.com/@robleathern/the-subprime-ad-crisis-is-here-6ac028133c93)
+
+## Formal papers
+
+- [A Consumer Perspective on AI & Advertising](https://www.harrietkingaby.com/reports)
+- [Weaponizing the Digital Influence Machine](https://datasociety.net/library/weaponizing-the-digital-influence-machine/)
+- [Confiding in Con Men: US Privacy Law, the GDPR, and Information Fiduciaries](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3354129)
+- [The Fiduciary Duties of User Agents](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3827421)
+- [Taking Trust Seriously in Privacy Law](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2655719)
+
+
+## Books
+
+- [Privacy in Context](https://www.amazon.com/Privacy-Context-Technology-Policy-Integrity/dp/0804752370)
+- [Subprime Attention Crisis](https://us.macmillan.com/books/9780374538651)


### PR DESCRIPTION
I've noticed a number of discussions have argued over "what do privacy advocates want?" and "what does privacy mean?" and often result in people asking for more information and sources. 

As a result, I think it would be best to include some reference material that represents a broad overview of privacy and user concerns. This list is not intended to be comprehensive, but basically a way that participants can familiarize themselves with the positions that tend to be least represented in our discussions (as in they do not often have individuals to represent these arguments). The goal here is that the next time someone asks "well what is the privacy that we're trying to achieve?" we can point to these documents as a starting point to help people understand what the perspective is we'd like to address. Please add links if they come up. 