### PR TITLE
Add a link to the PUFFIN repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Raise issues, add drafts. As you add a document, feel free to add a PR for its d
 * [TERN](https://github.com/WICG/turtledove/blob/master/TERN.md) (TURTLEDOVE Enhancements with Reduced Networking)
 * [PARRROT](https://github.com/prebid/identity-gatekeeper/blob/master/proposals/PARRROT.md) (PARRROT: The Publisher Auction Responsibility Retention Revision of TurtleDove)
 * [PELICAN](https://github.com/neustar/pelican) (Private Learning and Inference for Causal Attribution)
+* [PUFFIN](https://github.com/dmarti/PUFFIN) (Personal User Floors For Impression Negotiations)
 * [SPURFOWL](https://github.com/AdRoll/privacy/blob/main/SPURFOWL.md) (Sandboxed Private User Reporting Functions Operating Within Limits) and other [NextRoll proposals](https://github.com/AdRoll/privacy) including MURRE.
 * [TEETAR](https://github.com/criteo/privacy/blob/main/TEETAR/README.md)(TEETAR: Testing Environment Enabling Truthful and Actionable Results)
 * [FLEDGE](https://github.com/WICG/turtledove/blob/master/FLEDGE.md), the collection of proposals in the greater TURTLEDOVE idea space that Chrome plans to implement in 2021.


### PR DESCRIPTION
PUFFIN, Personal User Floor For Impression Negotiations, is an enhancement for TURTLEDOVE and related proposals, intended to enable users to incentivize the production and distribution of desired ad-supported content.